### PR TITLE
Improve UX for select

### DIFF
--- a/sass/inputs/_select.scss
+++ b/sass/inputs/_select.scss
@@ -8,6 +8,7 @@
     top: rem(10);
     right: rem(15);
     color: $sassy-base-color;
+    pointer-events: none;
   }
 
   /* Target IE9 and IE10 */


### PR DESCRIPTION
Adding the  `pointer-events: none` we will be able to click through the arrow. Right now, if you click exactly over the arrow, the select will not open.
